### PR TITLE
Add rewrites for Credo's ExpensiveEmptyEnumCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ the check can be configured further for fine tuning.
 | [`.UnlessWithElse`](https://hexdocs.pm/credo/Credo.Check.Refactor.UnlessWithElse.html)                       | Simplifies unless with else             | [Control Flow Macros](docs/control_flow_macros.md#if-and-unless)      |              |
 | [`.WithClauses`](https://hexdocs.pm/credo/Credo.Check.Refactor.WithClauses.html)                             | Optimizes with clauses                  | [Control Flow Macros](docs/control_flow_macros.md#with)               |              |
 
+### Credo.Check.Warning
+
+
+| Credo Check                                                                                                  | Rewrite Description                             | Documentation                                                         | Configurable |
+| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- | --------------------------------------------------------------------- | ------------ |
+| [`.ExpensiveEmptyEnumCheck`](https://hexdocs.pm/credo/Credo.Check.Warning.ExpensiveEmptyEnumCheck.html)      | Rewrites slow checks of enum emptiness          | [Single Node](docs/single_node.md#empty-enum-checks)                  |              |
+
 <!-- tabs-close -->
 
 ## License

--- a/docs/single_node.md
+++ b/docs/single_node.md
@@ -1,0 +1,28 @@
+# Single Node Transformations
+
+## Empty enum checks
+
+This addresses [`Credo.Check.Warning.ExpensiveEmptyEnumCheck`](https://hexdocs.pm/credo/Credo.Check.Warning.ExpensiveEmptyEnumCheck.html).  This is not configurable.
+
+Rewrites look like this:
+
+```elixir
+# Given:
+if enum |> MyModule.transform() |> length() == 0, do: "empty"
+# Styled:
+if enum |> MyModule.transform() |> Enum.empty?(), do: "empty"
+
+# Given:
+if Enum.count(enum) > 0, do: "not empty"
+# Styled:
+if not Enum.empty?(enum), do: "not empty"
+```
+
+Note that while Quokka will rewrite the calls to `length/1` or `Enum.count/1` even in pipes when the result is being checked for equality against zero, it will not rewrite pipes if they're being checked for being greater than zero. (Quokka avoids either wrapping the whole pipe chain in a `not` or piping into `Kernel.not/1`.)
+
+```elixir
+# Given:
+if foo |> MyModule.transform() |> Enum.count(enum) > 0, do: "not empty"
+# Styled (unchanged):
+if foo |> MyModule.transform() |> Enum.count(enum) > 0, do: "not empty"
+```

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -247,24 +247,14 @@ defmodule Quokka.Style.SingleNode do
     end
   end
 
-  @pipe_to_length_pattern quote do: {:|>, var!(pm), [var!(lhs), {:length, var!(lm), []}]}
+  @pipe_to_length_pattern quote do: {:|>, var!(pm), [var!(lhs), {:length, var!(m), []}]}
+  @pipe_to_count_pattern quote do: {:|>, var!(pm), [var!(lhs), {{:., var!(m), [{_, _, [:Enum]}, :count]}, _, []}]}
 
   for {lhs, rhs} <- [
         # foo |> bar() |> length() == 0 => foo |> bar() |> Enum.empty?()
         {@pipe_to_length_pattern, @literal_zero_pattern},
         # 0 == foo |> bar() |> length() => foo |> bar() |> Enum.empty?()
-        {@literal_zero_pattern, @pipe_to_length_pattern}
-      ] do
-    defp style({op, _, [unquote(lhs), unquote(rhs)]} = node) when op in [:==, :===] do
-      if Quokka.Config.inefficient_function_rewrites?(),
-        do: {:|>, pm, [lhs, {{:., lm, [{:__aliases__, lm, [:Enum]}, :empty?]}, lm, []}]},
-        else: node
-    end
-  end
-
-  @pipe_to_count_pattern quote do: {:|>, var!(pm), [var!(lhs), {{:., var!(cm), [{_, _, [:Enum]}, :count]}, _, []}]}
-
-  for {lhs, rhs} <- [
+        {@literal_zero_pattern, @pipe_to_length_pattern},
         # foo |> bar() |> Enum.count() == 0 => foo |> bar() |> Enum.empty?()
         {@pipe_to_count_pattern, @literal_zero_pattern},
         # 0 == foo |> bar() |> Enum.count() => foo |> bar() |> Enum.empty?()
@@ -272,7 +262,7 @@ defmodule Quokka.Style.SingleNode do
       ] do
     defp style({op, _, [unquote(lhs), unquote(rhs)]} = node) when op in [:==, :===] do
       if Quokka.Config.inefficient_function_rewrites?(),
-        do: {:|>, pm, [lhs, {{:., cm, [{:__aliases__, cm, [:Enum]}, :empty?]}, cm, []}]},
+        do: {:|>, pm, [lhs, {{:., m, [{:__aliases__, m, [:Enum]}, :empty?]}, m, []}]},
         else: node
     end
   end

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -24,6 +24,7 @@ defmodule Quokka.Style.SingleNode do
   * Credo.Check.Refactor.CondStatements
   * Credo.Check.Refactor.RedundantWithClauseResult
   * Credo.Check.Refactor.WithClauses
+  * Credo.Check.Warning.ExpensiveEmptyEnumCheck
   """
 
   @behaviour Quokka.Style
@@ -224,6 +225,74 @@ defmodule Quokka.Style.SingleNode do
   # `Enum.reverse(foo) ++ bar` => `Enum.reverse(foo, bar)`
   defp style({:++, _, [{{:., _, [{_, _, [:Enum]}, :reverse]} = reverse, r_meta, [lhs]}, rhs]}),
     do: {reverse, r_meta, [lhs, rhs]}
+
+  @literal_zero_pattern quote do: {:__block__, _, [0]}
+  @enum_count_pattern quote do: {{:., var!(m), [{_, _, [:Enum]}, :count]}, _, [var!(enum)]}
+  @length_pattern quote do: {:length, var!(m), [var!(enum)]}
+
+  for {lhs, rhs} <- [
+        # Enum.count(enum) == 0 => Enum.empty?(enum)
+        {@enum_count_pattern, @literal_zero_pattern},
+        # 0 == Enum.count(enum) => Enum.empty?(enum)
+        {@literal_zero_pattern, @enum_count_pattern},
+        # length(enum) == 0 => Enum.empty?(enum)
+        {@length_pattern, @literal_zero_pattern},
+        # 0 == length(enum) => Enum.empty?(enum)
+        {@literal_zero_pattern, @length_pattern}
+      ] do
+    defp style({op, _, [unquote(lhs), unquote(rhs)]} = node) when op in [:==, :===] do
+      if Quokka.Config.inefficient_function_rewrites?(),
+        do: {{:., m, [{:__aliases__, m, [:Enum]}, :empty?]}, m, [enum]},
+        else: node
+    end
+  end
+
+  @pipe_to_length_pattern quote do: {:|>, var!(pm), [var!(lhs), {:length, var!(lm), []}]}
+
+  for {lhs, rhs} <- [
+        # foo |> bar() |> length() == 0 => foo |> bar() |> Enum.empty?()
+        {@pipe_to_length_pattern, @literal_zero_pattern},
+        # 0 == foo |> bar() |> length() => foo |> bar() |> Enum.empty?()
+        {@literal_zero_pattern, @pipe_to_length_pattern}
+      ] do
+    defp style({op, _, [unquote(lhs), unquote(rhs)]} = node) when op in [:==, :===] do
+      if Quokka.Config.inefficient_function_rewrites?(),
+        do: {:|>, pm, [lhs, {{:., lm, [{:__aliases__, lm, [:Enum]}, :empty?]}, lm, []}]},
+        else: node
+    end
+  end
+
+  @pipe_to_count_pattern quote do: {:|>, var!(pm), [var!(lhs), {{:., var!(cm), [{_, _, [:Enum]}, :count]}, _, []}]}
+
+  for {lhs, rhs} <- [
+        # foo |> bar() |> Enum.count() == 0 => foo |> bar() |> Enum.empty?()
+        {@pipe_to_count_pattern, @literal_zero_pattern},
+        # 0 == foo |> bar() |> Enum.count() => foo |> bar() |> Enum.empty?()
+        {@literal_zero_pattern, @pipe_to_count_pattern}
+      ] do
+    defp style({op, _, [unquote(lhs), unquote(rhs)]} = node) when op in [:==, :===] do
+      if Quokka.Config.inefficient_function_rewrites?(),
+        do: {:|>, pm, [lhs, {{:., cm, [{:__aliases__, cm, [:Enum]}, :empty?]}, cm, []}]},
+        else: node
+    end
+  end
+
+  for {lhs, rhs, op} <- [
+        # Enum.count(enum) > 0 => not Enum.empty?(enum)
+        {@enum_count_pattern, @literal_zero_pattern, :>},
+        # 0 < Enum.count(enum) => not Enum.empty?(enum)
+        {@literal_zero_pattern, @enum_count_pattern, :<},
+        # length(enum) > 0 => not Enum.empty?(enum)
+        {@length_pattern, @literal_zero_pattern, :>},
+        # 0 < length(enum) => not Enum.empty?(enum)
+        {@literal_zero_pattern, @length_pattern, :<}
+      ] do
+    defp style({unquote(op), _, [unquote(lhs), unquote(rhs)]} = node) do
+      if Quokka.Config.inefficient_function_rewrites?(),
+        do: {:not, m, [{{:., m, [{:__aliases__, m, [:Enum]}, :empty?]}, m, [enum]}]},
+        else: node
+    end
+  end
 
   # ARROW REWRITES
   # `with`, `for` left arrow - if only we could write something this trivial for `->`!

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -83,6 +83,37 @@ defmodule Quokka.Style.SingleNodeTest do
     end
   end
 
+  describe "checking empty enums" do
+    test "length(enum) == 0 => Enum.empty?(enum)" do
+      assert_style("length(foo) == 0", "Enum.empty?(foo)")
+      assert_style("0 == length(foo)", "Enum.empty?(foo)")
+      assert_style("foo |> bar() |> length() === 0", "foo |> bar() |> Enum.empty?()")
+      assert_style("0 == foo |> bar() |> length()", "foo |> bar() |> Enum.empty?()")
+    end
+
+    test "Enum.count(enum) == 0 => Enum.empty?(enum)" do
+      assert_style("Enum.count(foo) == 0", "Enum.empty?(foo)")
+      assert_style("0 == Enum.count(foo)", "Enum.empty?(foo)")
+      assert_style("foo |> bar() |> Enum.count() === 0", "foo |> bar() |> Enum.empty?()")
+      assert_style("0 == foo |> bar() |> Enum.count()", "foo |> bar() |> Enum.empty?()")
+    end
+
+    test "length(enum) > 0 => not Enum.empty?(enum)" do
+      assert_style("length(foo) > 0", "not Enum.empty?(foo)")
+      assert_style("0 < length(foo)", "not Enum.empty?(foo)")
+    end
+
+    test "Enum.count(enum) > 0 => not Enum.empty?(enum)" do
+      assert_style("Enum.count(foo) > 0", "not Enum.empty?(foo)")
+      assert_style("0 < Enum.count(foo)", "not Enum.empty?(foo)")
+    end
+
+    test "does not monkey with other variants of length or count functions" do
+      assert_style("MyModule.length(foo) == 0", "MyModule.length(foo) == 0")
+      assert_style("MyModule.Enum.count(foo) == 0", "MyModule.Enum.count(foo) == 0")
+    end
+  end
+
   describe "Timex.now/0,1" do
     test "Timex.now/0 => DateTime.utc_now/0" do
       assert_style("Timex.now()", "DateTime.utc_now()")


### PR DESCRIPTION
This adds rewrites for unnecessarily expensive checks of an enum's emptiness, like `length(enum) == 0`.

While I handled cases where you pipe to `length/1`/`Enum.count/1` and check equality to 0, I intentionally did not rewrite the cases where you pipe to length/count and then check if the result is greater than zero:

```elixir
if foo |> bar() |> length() > 0 do
  "not empty"
else
  "empty"
end
```

Wrapping the whole pipe in a `not` seemed too ugly, and I am predisposed to avoid piping into `Kernel.not/1`. 😆