### PR TITLE
Skip autosort for ecto queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ in `.formatter.exs` to fine tune your setup:
       | :single_node
       # Don't re-underscore large numbers with underscores. Ie, leave 100_00 as-is.
       | :nums_with_underscores
+      # Don't autosort anything in an Ecto query
+      | :autosort_ecto
     ],
     piped_function_exclusions: [:subquery, :"Repo.update", ...]
   ]

--- a/docs/comment_directives.md
+++ b/docs/comment_directives.md
@@ -68,9 +68,9 @@ autosort: [:map, schema: [:field, :belongs_to]]
 
 The default order is: `[:field, :belongs_to, :has_many, :has_one, :many_to_many, :embeds_many, :embeds_one]`.
 
-Quokka will skip sorting entities that have comments inside them and entities within Ecto queries, since order can be important in this context. Sorting can still be forced with `# quokka:sort`. Finally, when `autosort` is enabled, a specific entity can be skipped by adding `# quokka:skip-sort` on the line above it.
+Quokka will skip sorting entities that have comments inside them, though sorting can still be forced with `# quokka:sort`. Finally, when `autosort` is enabled, a specific entity can be skipped by adding `# quokka:skip-sort` on the line above it.
 
-Sorting within Ecto queries can be disabled by specifying `autosort: [:exclude_ecto]`. If your codebase makes use of `union` queries, this option may be desirable, since `union` matches on position and not on name.
+Sorting within Ecto queries can be disabled by specifying `exclude: [:autosort_ecto]`. If your codebase makes use of `union` queries, this option may be desirable, since `union` matches on position and not on name.
 
 **Note on Ecto Query Detection**: Quokka uses pattern matching to identify Ecto queries and will skip autosorting maps within:
 - Remote calls to `Ecto.Query.from(...)`

--- a/docs/comment_directives.md
+++ b/docs/comment_directives.md
@@ -68,7 +68,9 @@ autosort: [:map, schema: [:field, :belongs_to]]
 
 The default order is: `[:field, :belongs_to, :has_many, :has_one, :many_to_many, :embeds_many, :embeds_one]`.
 
-Quokka will skip sorting entities that have comments inside them, though sorting can still be forced with `# quokka:sort`. Finally, when `autosort` is enabled, a specific entity can be skipped by adding `# quokka:skip-sort` on the line above it.
+Quokka will skip sorting entities that have comments inside them and entities within Ecto queries, since order can be important in this context. Sorting can still be forced with `# quokka:sort`. Finally, when `autosort` is enabled, a specific entity can be skipped by adding `# quokka:skip-sort` on the line above it.
+
+Sorting within Ecto queries can be disabled by specifying `autosort: [:exclude_ecto]`. If your codebase makes use of `union` queries, this option may be desirable, since `union` matches on position and not on name.
 
 #### Examples
 
@@ -159,3 +161,15 @@ defmodule MySchema do
 end
 ```
 
+When `autosort: [:exclude_ecto]` is enabled, the following will not get sorted:
+```
+query1 =
+  from u in "users",
+    select: %{
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      active: true,
+      role: "user"
+    }
+```

--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -98,6 +98,7 @@ defmodule Quokka.Config do
       # quokka:sort
       %{
         autosort: autosort,
+        autosort_exclude_ecto: quokka_config |> Keyword.get(:exclude, []) |> Enum.member?(:autosort_ecto),
         autosort_schema_order: autosort_schema_order,
         block_pipe_exclude: credo_opts[:block_pipe_exclude] || [],
         block_pipe_flag: credo_opts[:block_pipe_flag] || false,
@@ -172,6 +173,10 @@ defmodule Quokka.Config do
 
   def autosort_schema_order() do
     get(:autosort_schema_order)
+  end
+
+  def autosort_exclude_ecto?() do
+    get(:autosort_exclude_ecto)
   end
 
   def block_pipe_flag?() do

--- a/lib/style/comment_directives.ex
+++ b/lib/style/comment_directives.ex
@@ -53,7 +53,7 @@ defmodule Quokka.Style.CommentDirectives do
       is_query = is_ecto_from_query?(node)
 
       cond do
-        is_query and Enum.member?(autosort_types, :exclude_ecto) ->
+        is_query and Quokka.Config.autosort_exclude_ecto?() ->
           {:skip, zipper, %{ctx | comments: comments}}
 
         should_skip || has_comments || !is_sortable ->

--- a/test/style/comment_directives_test.exs
+++ b/test/style/comment_directives_test.exs
@@ -295,7 +295,8 @@ defmodule Quokka.Style.CommentDirectivesTest do
     end
 
     test "skips autosort for ecto queries" do
-      Mimic.stub(Quokka.Config, :autosort, fn -> [:map, :exclude_ecto] end)
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+      Mimic.stub(Quokka.Config, :autosort_exclude_ecto?, fn -> true end)
 
       assert_style("""
       defmodule Example do
@@ -329,7 +330,8 @@ defmodule Quokka.Style.CommentDirectivesTest do
     end
 
     test "skips autosort for remote Ecto.Query.from calls" do
-      Mimic.stub(Quokka.Config, :autosort, fn -> [:map, :exclude_ecto] end)
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+      Mimic.stub(Quokka.Config, :autosort_exclude_ecto?, fn -> true end)
 
       # Should not sort maps in remote Ecto.Query.from calls
       assert_style("""
@@ -348,7 +350,8 @@ defmodule Quokka.Style.CommentDirectivesTest do
     end
 
     test "does not skip autosort for non-Ecto from functions" do
-      Mimic.stub(Quokka.Config, :autosort, fn -> [:map, :exclude_ecto] end)
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+      Mimic.stub(Quokka.Config, :autosort_exclude_ecto?, fn -> true end)
 
       # Should sort maps in non-Ecto from functions (false positive prevention)
       assert_style(
@@ -392,7 +395,8 @@ defmodule Quokka.Style.CommentDirectivesTest do
     end
 
     test "correctly identifies Ecto queries with various patterns" do
-      Mimic.stub(Quokka.Config, :autosort, fn -> [:map, :exclude_ecto] end)
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+      Mimic.stub(Quokka.Config, :autosort_exclude_ecto?, fn -> true end)
 
       # Should not sort - standard Ecto query with 'in' clause
       assert_style("""


### PR DESCRIPTION
Closes #74 

I'm a little concerned that this is too crude a way to detect an Ecto query, but it may be good enough. I think the risk is relatively low -- worst case scenario, some things that should get autosorted will not be, and I can address those bugs as they come up. The other risk is that if a query is described as the following, then the `select` will still get autosorted -- but there's only so much I can engineer for:
```
# This map will still get sorted when autosort is on
select_map = %{name: name, email: email}

my_query = from u in users, select: ^select
```