### PR TITLE
Add changelog link to Hex package metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,10 @@ defmodule Quokka.MixProject do
   defp package() do
     [
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => @url}
+      links: %{
+        "Changelog" => "#{@url}/blob/main/CHANGELOG.md",
+        "GitHub" => @url
+      }
     ]
   end
 


### PR DESCRIPTION
Adds a "Changelog" link to the package metadata that will display on hex.pm. This makes it easier for users to find version history directly from the package page.

The changelog link points to the CHANGELOG.md file in the GitHub repository using the existing `@url` module attribute.