### PR TITLE
Run formatter on ignored files

### DIFF
--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -91,6 +91,8 @@ defmodule Quokka do
       ast_to_string(ast, comments, formatter_opts)
     else
       input
+      |> Code.format_string!(formatter_opts)
+      |> formatted_iodata_to_binary()
     end
   end
 
@@ -113,11 +115,13 @@ defmodule Quokka do
     opts = [{:comments, comments}, {:escape, false} | formatter_opts]
     line_length = Quokka.Config.line_length()
 
-    formatted =
-      ast
-      |> Code.quoted_to_algebra(opts)
-      |> Inspect.Algebra.format(line_length)
+    ast
+    |> Code.quoted_to_algebra(opts)
+    |> Inspect.Algebra.format(line_length)
+    |> formatted_iodata_to_binary()
+  end
 
+  defp formatted_iodata_to_binary(formatted) do
     case formatted do
       [] -> ""
       _ -> IO.iodata_to_binary([formatted, ?\n])


### PR DESCRIPTION
Hey! 

I noticed our ignored files were no longer being formatted at all because the plugin system [replaces the default formatter](https://github.com/elixir-lang/elixir/blob/e3f7759fded70267560ecf17cbdc2b2d3b482753/lib/mix/lib/mix/tasks/format.ex#L702).

This change runs the normal [elixir_format](https://github.com/elixir-lang/elixir/blob/e3f7759fded70267560ecf17cbdc2b2d3b482753/lib/mix/lib/mix/tasks/format.ex#L751) logic on files that are ignored at the quokka level.

I have not found time to add an automated test to this PR, but let me know if that is something you would like!