### PR TITLE
Rewrite inefficient Repo existence checks

### DIFF
--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -221,6 +221,18 @@ defmodule Quokka.Style.SingleNode do
     end
   end
 
+  # assert query |> Repo.one() => assert query |> Repo.exists?()
+  defp style(
+         {:assert, am, [{:|>, pipe_meta, [lhs, {{:., dm, [{:__aliases__, alias_meta, modules}, :one]}, funm, args}]}]} =
+           node
+       ) do
+    if Quokka.Config.inefficient_function_rewrites?() and List.last(modules) == :Repo do
+      {:assert, am, [{:|>, pipe_meta, [lhs, {{:., dm, [{:__aliases__, alias_meta, modules}, :exists?]}, funm, args}]}]}
+    else
+      node
+    end
+  end
+
   # if Repo.one(query) do => if Repo.exists?(query) do
   defp style({:if, im, [condition, body]} = node) do
     if Quokka.Config.inefficient_function_rewrites?() do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -764,6 +764,7 @@ defmodule Quokka.Style.SingleNodeTest do
     test "rewrites Repo.one in assertions to Repo.exists?" do
       # Make sure legitimate comparisons are not rewritten
       assert_style("assert Repo.one(query) == %{some: :struct}")
+      assert_style("assert Repo.one(query) |> Map.get(:my_key)")
 
       assert_style("assert Repo.one(query)", "assert Repo.exists?(query)")
       assert_style("assert MyApp.Repo.one(query)", "assert MyApp.Repo.exists?(query)")
@@ -821,6 +822,9 @@ defmodule Quokka.Style.SingleNodeTest do
     end
 
     test "rewrites Repo.one in refute statements to Repo.exists?" do
+      # Make sure legitimate comparisons are not rewritten
+      assert_style("refute Repo.one(query) |> Map.get(:my_key)")
+
       assert_style("refute Repo.one(query)", "refute Repo.exists?(query)")
       assert_style("refute MyApp.Repo.one(query)", "refute MyApp.Repo.exists?(query)")
 

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -798,6 +798,29 @@ defmodule Quokka.Style.SingleNodeTest do
       assert_style("if Repo.one(query), do: :ok", "if Repo.exists?(query), do: :ok")
     end
 
+    test "handles piped Repo.one calls in assertions" do
+      assert_style(
+        "assert from(stuff) |> Repo.one()",
+        "assert from(stuff) |> Repo.exists?()"
+      )
+
+      assert_style(
+        "assert query |> MyApp.Repo.one()",
+        "assert query |> MyApp.Repo.exists?()"
+      )
+
+      assert_style(
+        "assert from(u in User, where: u.active) |> DB.Repo.one(timeout: 5000)",
+        "assert from(u in User, where: u.active) |> DB.Repo.exists?(timeout: 5000)"
+      )
+
+      # Complex piped expressions
+      assert_style(
+        "assert query |> transform() |> Repo.one()",
+        "assert query |> transform() |> Repo.exists?()"
+      )
+    end
+
     test "respects inefficient_functions config" do
       stub(Quokka.Config, :inefficient_function_rewrites?, fn -> false end)
       assert_style("assert Repo.one(query)")


### PR DESCRIPTION
```elixir
assert Repo.one(query)
# =>
assert Repo.exists?(query)
```

This one has been bugging me for a while :)