### PR TITLE
Map.drop & Map.delete piping auto-rewrites

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -389,6 +389,82 @@ defmodule Quokka.Style.Pipes do
     {:|>, pm, [lhs, rhs]}
   end
 
+  # `lhs |> Map.delete(key1) |> Map.delete(key2)` => `lhs |> Map.drop([key1, key2])`
+  defp fix_pipe(
+         pipe_chain(
+           pm,
+           lhs,
+           {{:., dm, [{_, _, [:Map]}, :delete]}, meta, [key1]},
+           {{:., _, [{_, _, [:Map]}, :delete]}, _, [key2]}
+         )
+       ) do
+    if Quokka.Config.inefficient_function_rewrites?() do
+      keys = {:__block__, meta, [[key1, key2]]}
+      drop_call = {{:., dm, [{:__aliases__, dm, [:Map]}, :drop]}, meta, [keys]}
+      # recurse to handle the case of Map.delete followed by Map.drop
+      fix_pipe({:|>, pm, [lhs, drop_call]})
+    else
+      {:|>, pm, [lhs, {{:., dm, [{:__aliases__, dm, [:Map]}, :delete]}, meta, [key1]}]}
+    end
+  end
+
+  # `lhs |> Map.delete(key1) |> Map.drop([key2, key3])` => `lhs |> Map.drop([key1, key2, key3])`
+  defp fix_pipe(
+         pipe_chain(
+           pm,
+           lhs,
+           {{:., dm, [{_, _, [:Map]}, :delete]}, meta, [key1]},
+           {{:., _, [{_, _, [:Map]}, :drop]}, _, [{:__block__, _, [existing_keys]}]}
+         )
+       ) do
+    if Quokka.Config.inefficient_function_rewrites?() do
+      keys = {:__block__, meta, [[key1 | existing_keys]]}
+      drop_call = {{:., dm, [{:__aliases__, dm, [:Map]}, :drop]}, meta, [keys]}
+      # recursively continue simplifying Map.delete/Map.drop chains
+      fix_pipe({:|>, pm, [lhs, drop_call]})
+    else
+      {:|>, pm, [lhs, {{:., dm, [{:__aliases__, dm, [:Map]}, :delete]}, meta, [key1]}]}
+    end
+  end
+
+  # `lhs |> Map.drop([key1, key2]) |> Map.delete(key3)` => `lhs |> Map.drop([key1, key2, key3])`
+  defp fix_pipe(
+         pipe_chain(
+           pm,
+           lhs,
+           {{:., dm, [{_, _, [:Map]}, :drop]}, meta, [{:__block__, _, [existing_keys]}]},
+           {{:., _, [{_, _, [:Map]}, :delete]}, _, [key3]}
+         )
+       ) do
+    if Quokka.Config.inefficient_function_rewrites?() do
+      keys = {:__block__, meta, [existing_keys ++ [key3]]}
+      drop_call = {{:., dm, [{:__aliases__, dm, [:Map]}, :drop]}, meta, [keys]}
+      # recursively continue simplifying Map.delete/Map.drop chains
+      fix_pipe({:|>, pm, [lhs, drop_call]})
+    else
+      {:|>, pm, [lhs, {{:., dm, [{:__aliases__, dm, [:Map]}, :drop]}, meta, [{:__block__, meta, [existing_keys]}]}]}
+    end
+  end
+
+  # `lhs |> Map.drop([key1, key2]) |> Map.drop([key3, key4])` => `lhs |> Map.drop([key1, key2, key3, key4])`
+  defp fix_pipe(
+         pipe_chain(
+           pm,
+           lhs,
+           {{:., dm, [{_, _, [:Map]}, :drop]}, meta, [{:__block__, _, [existing_keys1]}]},
+           {{:., _, [{_, _, [:Map]}, :drop]}, _, [{:__block__, _, [existing_keys2]}]}
+         )
+       ) do
+    if Quokka.Config.inefficient_function_rewrites?() do
+      keys = {:__block__, meta, [existing_keys1 ++ existing_keys2]}
+      drop_call = {{:., dm, [{:__aliases__, dm, [:Map]}, :drop]}, meta, [keys]}
+      # recursively continue simplifying Map.delete/Map.drop chains
+      fix_pipe({:|>, pm, [lhs, drop_call]})
+    else
+      {:|>, pm, [lhs, {{:., dm, [{:__aliases__, dm, [:Map]}, :drop]}, meta, [{:__block__, meta, [existing_keys1]}]}]}
+    end
+  end
+
   # `lhs |> Enum.map(mapper) |> Enum.into(empty_map)` => `lhs |> Map.new(mapper)`
   # or
   # `lhs |> Enum.map(mapper) |> Enum.into(collectable)` => `lhs |> Enum.into(collectable, mapper)


### PR DESCRIPTION
It'd be nice to auto rewrite the following cases:

1. Consecutive Map.deletes to single Map.drop

From

```elixir
x
|> Map.delete(key1)
|> Map.delete(key2)
```

to

```elixir
x
|> Map.drop([key1, key2])
```
2. Consecutive Map.drops to single Map.drop

From

```elixir
x
|> Map.drop([key1, key2])
|> Map.drop([key3, key4])
```

to

```elixir
x
|> Map.drop([key1, key2, key3, key4])
```

3. Consecutive Map.delete, Map.drop (or vice-versa) to single Map.drop

From

```elixir
x
|> Map.delete(key1)
|> Map.drop([key2, key3])
```

to

```elixir
x
|> Map.drop([key1, key2, key3])
```

If this approach sounds good, I'd love to update any docs needed and later, put up a followup PR for Keyword as well.