### PR TITLE
[fix] The project elixir isn't always present

### DIFF
--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -365,7 +365,9 @@ defmodule Quokka.Config do
   end
 
   defp parse_elixir_version() do
-    case Regex.run(~r/(?:==|>=|>|~>)?\s*(\d+(?:\.\d+(?:\.\d+(?:-\w+)?)?)?)\b/, Mix.Project.config()[:elixir]) do
+    project_elixir = Keyword.get(Mix.Project.config(), :elixir) || ""
+
+    case Regex.run(~r/(?:==|>=|>|~>)?\s*(\d+(?:\.\d+(?:\.\d+(?:-\w+)?)?)?)\b/, project_elixir) do
       [_, version] ->
         case String.split(version, ".") do
           [major] -> "#{major}.0.0"


### PR DESCRIPTION
When running in a language server context, it's possible that the version isn't set in the project. Similarly, there are other contexts where you might want to use Quokka (like as a library).

The current version parsing relies on the project existing and its elixir version being set. If the latter isn't true, then the current code returns nil, which causes the regex match to fail.

This fixes the failure by defaulting to an empty string, which will cause the system version to be used.