### PR TITLE
Conditionally dealias of behaviour, moduledoc, shortdoc

### DIFF
--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -270,7 +270,7 @@ defmodule Quokka.Style.ModuleDirectivesTest do
           :alias,
           :behaviour,
           :moduledoc,
-          :shortdoc,
+          :shortdoc
         ]
       end)
 

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -263,6 +263,29 @@ defmodule Quokka.Style.ModuleDirectivesTest do
         """
       )
     end
+
+    test "does not dealias attr directives if not needed" do
+      stub(Quokka.Config, :strict_module_layout_order, fn ->
+        [
+          :alias,
+          :behaviour,
+          :moduledoc,
+          :shortdoc,
+        ]
+      end)
+
+      assert_style("""
+      defmodule Foo do
+        alias Foo.Bar
+
+        @behaviour Bar
+
+        @moduledoc "This module \#{Bar}"
+
+        @shortdoc "This module \#{Bar}"
+      end
+      """)
+    end
   end
 
   describe "strange parents!" do


### PR DESCRIPTION
Hi Quokka team!

This small PR addresses an issue that I am facing with dealiasing for moduledocs when the alias is above it in the module layout.

If I set the following order:

```
alias
moduledoc
```

The following happens:

```elixir
# Before format
defmodule Foo do
  alias Foo.Bar

  @moduledoc "A documentation with some #{Bar}"
end

# After format
defmodule Foo do
  alias Foo.Bar

  @moduledoc "A documentation with some #{Foo.Bar}"
end
```

Ideally, Quokka should consider the order and not dealias if it is not needed:

```elixir
# Before format
defmodule Foo do
  alias Foo.Bar

  @moduledoc "A documentation with some #{Bar}"
end

# After format
defmodule Foo do
  alias Foo.Bar

  @moduledoc "A documentation with some #{Bar}"
end
```

Please let me know what you think, and feel free to suggest changes or merge this PR.