### PR TITLE
Include a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+
+<!-- Provide a brief description of what this PR does -->
+
+## PR Checklist
+
+<!--
+You don't actually need to include this section in your PR, but following this list
+helps us a ton, especially reminders for updating docs so we don't have to change
+them ourselves before releases ❤️
+-->
+
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] All new and existing tests pass
+- [ ] If there are changes to installation, usage, or project overview, I have updated README.md
+- [ ] If there are changes to styling, I have updated the relevant `/docs/*.md` file
+- [ ] I have run `mix format` and committed any changes


### PR DESCRIPTION
Per [the docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository), this should automatically appear in future PRs, saving us a little time looking for the basics.