### PR TITLE
fix: strict module layout styling fails for non-existent keys

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -299,7 +299,7 @@ defmodule Quokka.Style.ModuleDirectives do
 
     directives =
       Quokka.Config.strict_module_layout_order()
-      |> Enum.map(&acc[&1])
+      |> Enum.map(&Map.get(acc, &1, []))
       |> Stream.concat()
       |> fix_line_numbers(List.first(nondirectives))
 

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -286,6 +286,41 @@ defmodule Quokka.Style.ModuleDirectivesTest do
       end
       """)
     end
+
+    test "handles custom order with non-existent keys" do
+      stub(Quokka.Config, :strict_module_layout_order, fn ->
+        [
+          :shortdoc,
+          :moduledoc,
+          :callback,
+          :behaviour,
+          :use,
+          :import,
+          :alias,
+          :require
+        ]
+      end)
+
+      assert_style(
+        """
+        defmodule Foo do
+          alias A.A
+          use B
+          @moduledoc "test"
+          @shortdoc "short"
+        end
+        """,
+        """
+        defmodule Foo do
+          @shortdoc "short"
+          @moduledoc "test"
+          use B
+
+          alias A.A
+        end
+        """
+      )
+    end
   end
 
   describe "strange parents!" do


### PR DESCRIPTION
fixes #114 