### PR TITLE
Handle rewriting anonymous function captures of variables

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -198,6 +198,11 @@ Rewrites inefficient anonymous function captures to more efficient function capt
 &SomeModule.func/2
 
 # Before
+&some_var.(&1)
+# Styled
+some_var
+
+# Before
 Enum.filter(my_enum, &my_function(&1))
 # Styled
 Enum.filter(my_enum, &my_function/1)

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -475,6 +475,12 @@ defmodule Quokka.Style.SingleNode do
     end
   end
 
+  # Rewrite &variable.(&1) to just the variable
+  defp style({:&, _meta, [{{:., _dot_meta, [{_var_name, _var_meta, _} = var]}, _fun_meta, [{:&, _, [arg_num]}]}]})
+       when is_integer(arg_num) do
+    var
+  end
+
   defp style({:&, meta, [{fun, fun_meta, [{:&, _, [arg_num]}]}]} = node) when is_integer(arg_num) do
     if Quokka.Config.inefficient_function_rewrites?() do
       fun_name =

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -1237,8 +1237,26 @@ defmodule Quokka.Style.SingleNodeTest do
     test "rewrites &anon_func(&n) to &anon_func/n" do
       assert_style("&my_function(&1)", "&my_function/1")
       assert_style("&SomeModule.func(&1)", "&SomeModule.func/1")
+      assert_style("&some_variable.(&1)", "some_variable")
       assert_style("&my_function(&2)", "&my_function/2")
       assert_style("&SomeModule.func(&2)", "&SomeModule.func/2")
+
+      assert_style(
+        """
+        admin? = fn %{user_id: user_id} ->
+          user_id == 1
+        end
+
+        Enum.any?(users, &admin?.(&1))
+        """,
+        """
+        admin? = fn %{user_id: user_id} ->
+          user_id == 1
+        end
+
+        Enum.any?(users, admin?)
+        """
+      )
     end
 
     test "works in various contexts" do


### PR DESCRIPTION
Followup to #110

This was previously crashing trying to rewrite this (admittedly goofy) code:

```elixir
admin? = fn %{user_id: user_id} ->
  ...
end

Enum.any?(users, &admin?.(&1))
```