### PR TITLE
Fix inefficient function rewrites on Map.reduce arguments

### DIFF
--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -477,6 +477,11 @@ defmodule Quokka.Style.SingleNode do
 
   # Rewrite &variable.(&1) to just the variable when the first argument is
   # a simple variable name, but not an anonymous function argument.
+  #
+  # Do this:
+  #   &some_variable.(&1) => some_variable
+  # But not:
+  #   & &1.(&2) => &1 (totally invalid syntax)
   defp style({:&, meta, [{{:., dot_meta, [{var_name, _meta, _context} = var]}, fun_meta, [{:&, arg_meta, [arg_num]}]}]})
        when is_integer(arg_num) do
     if is_atom(var_name) and not anonymous_arg?(var_name) do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -1280,6 +1280,7 @@ defmodule Quokka.Style.SingleNodeTest do
       assert_style("&func(&1 + 1)")
       assert_style("&func(some_arg, &1)")
       assert_style("&(&1 + &2)")
+      assert_style("& &1.(&2)")
     end
   end
 end


### PR DESCRIPTION
This fixes an incorrect rewrite I found in my codebase where we had a bunch of functions that rewrote a string like this:

```elixir
remove_newlines = &String.replace(&1, "\n", "")
remove_dashes = &String.replace(&1, "-", "")
```

...and then we reduced over all the functions like this:

```elixir
Enum.reduce([remove_newlines, remove_dashes], str_to_modify, & &1.(&2))
```

This, of course, is saying to pass the accumulated string into each of the functions in turn. It was being rewritten, though, to just:

```elixir
Enum.reduce([remove_newlines, remove_dashes], str_to_modify, &1)
```

...which is invalid.