### PR TITLE
Rewrite Map/Keyword.get(lhs, key, nil) to Map/Keyword.get(lhs, key)

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -43,7 +43,7 @@ All these rewrites are configurable by setting the `exclude: [:inefficient_funct
 
 ### Empty enum checks
 
-This addresses [`Credo.Check.Warning.ExpensiveEmptyEnumCheck`](https://hexdocs.pm/credo/Credo.Check.Warning.ExpensiveEmptyEnumCheck.html).  This is not configurable.
+This addresses [`Credo.Check.Warning.ExpensiveEmptyEnumCheck`](https://hexdocs.pm/credo/Credo.Check.Warning.ExpensiveEmptyEnumCheck.html). This is not configurable.
 
 Rewrites look like this:
 
@@ -136,6 +136,22 @@ Map.delete(map, key)
 Keyword.drop(kw, [key])
 # Styled
 Keyword.delete(kw, key)
+```
+
+### Map/Keyword.get(lhs, key, nil) -> Map/Keyword.get(lhs, key)
+
+In the same vein as the `merge` style above, `[Map|Keyword].drop/2` with a single key to drop are rewritten to use `delete/2`
+
+```elixir
+# Before
+Map.get(map, key, nil)
+# Styled
+Map.get(map, key)
+
+# Before
+Keyword.get(kw, key, nil)
+# Styled
+Keyword.get(kw, key)
 ```
 
 ### `Enum.reverse/1` and concatenation -> `Enum.reverse/2`
@@ -256,7 +272,6 @@ Enum.join(["a", "b", "c"], ", ", &String.upcase/1)
 
 Quokka will rewrite functions whose entire body is a try/do to instead use the implicit try syntax. Addresses [`Credo.Check.Readability.PreferImplicitTry`](https://hexdocs.pm/credo/Credo.Check.Readability.PreferImplicitTry.html). This is not configurable.
 
-
 The following example illustrates the most complex case, but Quokka happily handles just basic try do/rescue bodies just as easily.
 
 ### Before
@@ -329,19 +344,20 @@ defmacrop foo
 
 ## Elixir Deprecation Rewrites
 
-| Before                                       | After                              | Elixir Version |
-| -------------------------------------------- | ---------------------------------- | ------------- |
-| `Logger.warn`                                | `Logger.warning`                   | 1.15+         |
-| `Path.safe_relative_to/2`                    | `Path.safe_relative/2`             | 1.15+         |
-| `~R/my_regex/`                               | `~r/my_regex/`                     | 1.15+         |
-| `Enum/String.slice/2` with decreasing ranges | add explicit steps to the range \* | 1.15+         |
-| `Date.range/2` with decreasing range         | `Date.range/3` \*                  | 1.15+         |
-| `IO.read/bin_read` with `:all` option        | replace `:all` with `:eof`         | 1.15+         |
-| `File.stream!(path, [encoding: :utf8, trim_bom: true], :line)` (`:line` `:bytes` deprecated) | `File.stream!(path, :line, encoding: :utf8, trim_bom: true)` | 1.16+         |
-| `:timer.units(x)`                            | `to_time(unit: x)`                 | 1.17+         |
-| `first..last = ...`                         | `first..last//_ = ...`             | 1.18+         |
-| `List.zip(list1, list2)`                    | `Enum.zip(list1, list2)`           | 1.18+         |
-| `%Foo{x \| y} => %{x \| y}`                 | `%{x \| y}`                        | 1.19+         |
+| Before                                                                                       | After                                                        | Elixir Version |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | -------------- |
+| `Logger.warn`                                                                                | `Logger.warning`                                             | 1.15+          |
+| `Path.safe_relative_to/2`                                                                    | `Path.safe_relative/2`                                       | 1.15+          |
+| `~R/my_regex/`                                                                               | `~r/my_regex/`                                               | 1.15+          |
+| `Enum/String.slice/2` with decreasing ranges                                                 | add explicit steps to the range \*                           | 1.15+          |
+| `Date.range/2` with decreasing range                                                         | `Date.range/3` \*                                            | 1.15+          |
+| `IO.read/bin_read` with `:all` option                                                        | replace `:all` with `:eof`                                   | 1.15+          |
+| `File.stream!(path, [encoding: :utf8, trim_bom: true], :line)` (`:line` `:bytes` deprecated) | `File.stream!(path, :line, encoding: :utf8, trim_bom: true)` | 1.16+          |
+| `:timer.units(x)`                                                                            | `to_time(unit: x)`                                           | 1.17+          |
+| `first..last = ...`                                                                          | `first..last//_ = ...`                                       | 1.18+          |
+| `List.zip(list1, list2)`                                                                     | `Enum.zip(list1, list2)`                                     | 1.18+          |
+| `%Foo{x \| y} => %{x \| y}`                                                                  | `%{x \| y}`                                                  | 1.19+          |
+
 \* For both of the "decreasing range" changes, the rewrite can only be applied if the range is being passed as an argument to the function.
 
 ## Putting variable matching on the right

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -1233,6 +1233,50 @@ defmodule Quokka.Style.SingleNodeTest do
     end
   end
 
+  describe "Map.get/3 with nil default rewrites" do
+    test "rewrites Map.get(map, key, nil) to Map.get(map, key)" do
+      assert_style("Map.get(map, :key, nil)", "Map.get(map, :key)")
+      assert_style("Map.get(map, \"key\", nil)", "Map.get(map, \"key\")")
+      assert_style("Map.get(map, key, nil)", "Map.get(map, key)")
+
+      assert_style("map |> Map.get(:key, nil)", "map |> Map.get(:key)")
+      assert_style("map |> Map.get(\"key\", nil)", "map |> Map.get(\"key\")")
+      assert_style("map |> Map.get(key, nil)", "map |> Map.get(key)")
+    end
+
+    test "preserves Map.get with non-nil defaults" do
+      assert_style("Map.get(map, key, default)")
+      assert_style("Map.get(map, key, \"default\")")
+      assert_style("Map.get(map, key, :default)")
+
+      assert_style("map |> Map.get(key, default)")
+      assert_style("map |> Map.get(key, \"default\")")
+      assert_style("map |> Map.get(key, :default)")
+    end
+  end
+
+  describe "Keyword.get/3 with nil default rewrites" do
+    test "rewrites Keyword.get(kw, key, nil) to Keyword.get(kw, key)" do
+      assert_style("Keyword.get(kw, :key, nil)", "Keyword.get(kw, :key)")
+      assert_style("Keyword.get(kw, \"key\", nil)", "Keyword.get(kw, \"key\")")
+      assert_style("Keyword.get(kw, key, nil)", "Keyword.get(kw, key)")
+
+      assert_style("kw |> Keyword.get(:key, nil)", "kw |> Keyword.get(:key)")
+      assert_style("kw |> Keyword.get(\"key\", nil)", "kw |> Keyword.get(\"key\")")
+      assert_style("kw |> Keyword.get(key, nil)", "kw |> Keyword.get(key)")
+    end
+
+    test "preserves Keyword.get with non-nil defaults" do
+      assert_style("Keyword.get(kw, key, default)")
+      assert_style("Keyword.get(kw, key, \"default\")")
+      assert_style("Keyword.get(kw, key, :default)")
+
+      assert_style("kw |> Keyword.get(key, default)")
+      assert_style("kw |> Keyword.get(key, \"default\")")
+      assert_style("kw |> Keyword.get(key, :default)")
+    end
+  end
+
   describe "anonymous function capture rewrites" do
     test "rewrites &anon_func(&n) to &anon_func/n" do
       assert_style("&my_function(&1)", "&my_function/1")


### PR DESCRIPTION
## Description


```elixir
# Before
Map.get(lhs, key, nil)
lhs |> Map.get(key, nil)

Keyword.get(lhs, key, nil)
lhs |> Keyword.get(key, nil)

# Styled
Map.get(lhs, key)
lhs |> Map.get(key)

Keyword.get(lhs, key)
lhs |> Keyword.get(key)
```
## PR Checklist

<!--
You don't actually need to include this section in your PR, but following this list
helps us a ton, especially reminders for updating docs so we don't have to change
them ourselves before releases ❤️
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes


## Other Considerations

Can't rewrite Map.get(x, val, nil) to x[val] in case x is a struct since it doesn't implement Access protocol.
